### PR TITLE
Ryan durham code review2

### DIFF
--- a/app/src/main/java/com/rentminder/dao/IHouseholdDAO.kt
+++ b/app/src/main/java/com/rentminder/dao/IHouseholdDAO.kt
@@ -6,5 +6,5 @@ import retrofit2.http.GET
 
 interface IHouseholdDAO {
     @GET("")
-    fun getAllCountries() : Call<ArrayList<Household>>
+    fun getAllHouseholds() : Call<ArrayList<Household>>
 }

--- a/app/src/main/java/com/rentminder/dto/Household.kt
+++ b/app/src/main/java/com/rentminder/dto/Household.kt
@@ -1,7 +1,7 @@
 package com.rentminder.dto
 
-data class Household (var householdId : Int = 0, var houseName : String, var houseMembers : Int){
+data class Household (var householdId : Int = 0, var householdName : String, var householdMembers : Int){
     override fun toString(): String {
-        return "$houseName $houseMembers Members"
+        return "$householdName $householdMembers Members"
     }
 }

--- a/app/src/main/java/com/rentminder/service/HouseholdService.kt
+++ b/app/src/main/java/com/rentminder/service/HouseholdService.kt
@@ -12,8 +12,8 @@ class HouseholdService {
     suspend fun fetchHouseholds() : List<Household>?{
         return withContext(Dispatchers.IO) {
             val service = RetrofitClientInstance.retrofitInstance?.create(IHouseholdDAO::class.java)
-            val country = async { service?.getAllCountries() }
-            return@withContext country.await()?.awaitResponse<ArrayList<Household>>()?.body()
+            val houseHolds = async { service?.getAllCountries() }
+            return@withContext houseHolds.await()?.awaitResponse<ArrayList<Household>>()?.body()
         }
     }
 }

--- a/app/src/main/java/com/rentminder/service/HouseholdService.kt
+++ b/app/src/main/java/com/rentminder/service/HouseholdService.kt
@@ -9,11 +9,18 @@ import kotlinx.coroutines.withContext
 import retrofit2.awaitResponse
 
 class HouseholdService {
-    suspend fun fetchHouseholdsList() : List<Household>?{
+    private val service: IHouseholdDAO by lazy {
+        RetrofitClientInstance.retrofitInstance?.create(IHouseholdDAO::class.java)
+            ?: throw IllegalStateException("RetrofitClientInstance is null")
+    }
+
+    suspend fun fetchHouseholdsList() : List<Household>{
         return withContext(Dispatchers.IO) {
-            val service = RetrofitClientInstance.retrofitInstance?.create(IHouseholdDAO::class.java)
-            val houseHolds = async { service?.getAllCountries() }
-            return@withContext houseHolds.await()?.awaitResponse<ArrayList<Household>>()?.body()
+            try {
+                service.getAllHouseholds().awaitResponse().body() ?: emptyList()
+            } catch (e: Exception) {
+                emptyList()
+            }
         }
     }
 }

--- a/app/src/main/java/com/rentminder/service/HouseholdService.kt
+++ b/app/src/main/java/com/rentminder/service/HouseholdService.kt
@@ -9,7 +9,7 @@ import kotlinx.coroutines.withContext
 import retrofit2.awaitResponse
 
 class HouseholdService {
-    suspend fun fetchHouseholds() : List<Household>?{
+    suspend fun fetchHouseholdsList() : List<Household>?{
         return withContext(Dispatchers.IO) {
             val service = RetrofitClientInstance.retrofitInstance?.create(IHouseholdDAO::class.java)
             val houseHolds = async { service?.getAllCountries() }

--- a/app/src/main/java/com/rentminder/service/MembersService.kt
+++ b/app/src/main/java/com/rentminder/service/MembersService.kt
@@ -12,11 +12,8 @@ class MembersService {
     suspend fun fetchMembers() : List<Members>? {
         return withContext(Dispatchers.IO){
             val service = RetrofitClientInstance.retrofitInstance?.create(MembersDAO::class.java)
-            val members = async {service?.getAllMembers()}
-            var result =  members.await()?.awaitResponse()?.body()
-            return@withContext result
+            val members = async {service?.getAllMembers()?.awaitResponse()?.body() }
+            return@withContext members?.await()
         }
-
     }
-
 }

--- a/app/src/main/java/com/rentminder/service/MembersService.kt
+++ b/app/src/main/java/com/rentminder/service/MembersService.kt
@@ -9,11 +9,18 @@ import kotlinx.coroutines.withContext
 import retrofit2.awaitResponse
 
 class MembersService {
-    suspend fun fetchMembersList() : List<Members> {
-        return withContext(Dispatchers.IO){
-            val service = RetrofitClientInstance.retrofitInstance?.create(MembersDAO::class.java)
-            val members = async {service?.getAllMembers()?.awaitResponse()?.body() }
-            return@withContext members.await()?: emptyList()
+    private val service: MembersDAO by lazy {
+        RetrofitClientInstance.retrofitInstance?.create(MembersDAO::class.java)
+            ?: throw IllegalStateException("RetrofitClientInstance is null")
+    }
+
+    suspend fun fetchMembersList(): List<Members> {
+        return withContext(Dispatchers.IO) {
+            try {
+                service.getAllMembers().awaitResponse().body() ?: emptyList()
+            } catch (e: Exception) {
+                emptyList()
+            }
         }
     }
 }

--- a/app/src/main/java/com/rentminder/service/MembersService.kt
+++ b/app/src/main/java/com/rentminder/service/MembersService.kt
@@ -13,7 +13,7 @@ class MembersService {
         return withContext(Dispatchers.IO){
             val service = RetrofitClientInstance.retrofitInstance?.create(MembersDAO::class.java)
             val members = async {service?.getAllMembers()?.awaitResponse()?.body() }
-            return@withContext members?.await()
+            return@withContext members?.await()?: emptyList()
         }
     }
 }

--- a/app/src/main/java/com/rentminder/service/MembersService.kt
+++ b/app/src/main/java/com/rentminder/service/MembersService.kt
@@ -9,11 +9,11 @@ import kotlinx.coroutines.withContext
 import retrofit2.awaitResponse
 
 class MembersService {
-    suspend fun fetchMembersList() : List<Members>? {
+    suspend fun fetchMembersList() : List<Members> {
         return withContext(Dispatchers.IO){
             val service = RetrofitClientInstance.retrofitInstance?.create(MembersDAO::class.java)
             val members = async {service?.getAllMembers()?.awaitResponse()?.body() }
-            return@withContext members?.await()?: emptyList()
+            return@withContext members.await()?: emptyList()
         }
     }
 }

--- a/app/src/main/java/com/rentminder/service/MembersService.kt
+++ b/app/src/main/java/com/rentminder/service/MembersService.kt
@@ -9,7 +9,7 @@ import kotlinx.coroutines.withContext
 import retrofit2.awaitResponse
 
 class MembersService {
-    suspend fun fetchMembers() : List<Members>? {
+    suspend fun fetchMembersList() : List<Members>? {
         return withContext(Dispatchers.IO){
             val service = RetrofitClientInstance.retrofitInstance?.create(MembersDAO::class.java)
             val members = async {service?.getAllMembers()?.awaitResponse()?.body() }

--- a/app/src/test/java/com/rentminder/HouseholdUnitTest.kt
+++ b/app/src/test/java/com/rentminder/HouseholdUnitTest.kt
@@ -9,8 +9,8 @@ class HouseholdUnitTest {
     @Test
     fun `given a household dto when name is Uptown and members are 5 then name is Uptown and members are five`(){
         var household = Household(1, "Uptown", 5)
-        Assert.assertTrue(household.houseName.equals("Uptown"))
-        Assert.assertTrue(household.houseMembers.equals(5))
+        Assert.assertTrue(household.householdName.equals("Uptown"))
+        Assert.assertTrue(household.householdMembers.equals(5))
     }
 
     @Test


### PR DESCRIPTION
## Analysis of the program
The program looks pretty good for the most part. There are a few areas where things can be optimized a bit more, look at my changes to see. The naming conventions are generally good, but some are inconsistent/not descriptive enough. It seems they have added a lot since sprint 1, and have made significant progress.

## Was the program available in UC Github on time?
yes

## Is the program documented/commented well enough to understand?
yes

## Does the program compile?
yes

## Rationale behind changes
### Implemented Lazy Delegate to both the HouseholdService and MembersService
I implemented lazy to initialize RetrofitClientInstance. This is because with the current implementation you guys have, everytime you call either fetch function (there is a fetch function in both services) it will reinitialize the RetrofitClientInstance, which can waste time, and memory. Here is the implementation :
```
    private val service: IHouseholdDAO by lazy {
        RetrofitClientInstance.retrofitInstance?.create(IHouseholdDAO::class.java)
            ?: throw IllegalStateException("RetrofitClientInstance is null")
    }
```
```
    private val service: MembersDAO by lazy {
        RetrofitClientInstance.retrofitInstance?.create(MembersDAO::class.java)
            ?: throw IllegalStateException("RetrofitClientInstance is null")
    }
```
https://kotlinlang.org/docs/delegated-properties.html
https://kotlinlang.org/docs/delegated-properties.html#lazy-properties

### Added try catch block to HouseholdService and MemberService
I added a try catch block to both the HouseholdServcie and MemberService. This change was aimed at preventing the application from crashing if there was any exceptions thrown, or if there was a null returned for either of the Lists. If either of those two scenarios were to happen, it would return an emptyList() to avoid the app crashing. For example are the changes in HouseHoldService:
```
            val service = RetrofitClientInstance.retrofitInstance?.create(IHouseholdDAO::class.java)
            val houseHolds = async { service?.getAllCountries() }
            return@withContext houseHolds.await()?.awaitResponse<ArrayList<Household>>()?.body()
```
```
            try {
                service.getAllHouseholds().awaitResponse().body() ?: emptyList()
            } catch (e: Exception) {
                emptyList()
            }
```
One thing to note, is this change looks like it removes val service, but its actually implemented using lazy as talked about earlier.
https://kotlinlang.org/docs/flow.html#collector-try-and-catch


### Renamed the function fetchMembers()
I renamed the function because 'fetchMembers()' to 'fetchMembersList()'. This makes it easier to understand what the function is returning for future use.
https://kotlinlang.org/docs/coding-conventions.html#function-names

### Renamed the function fetchHouseholds()
I renamed the function because 'fetchHouseholds()' to 'fetchHouseholdsList()'. This makes it easier to understand what the function is returning for future use.
https://kotlinlang.org/docs/coding-conventions.html#function-names

### Renamed some variables in the Household DTO
The first variable inside the Household DTO was name householdID, and the following variables were houseX (X being the rest of the variable name i.e. "Name", "houseName"). I changed said variables to householdX to both make the variable more descriptive, but also make the naming more consistent with the first variable. For example here are the changes:
`(var householdId : Int = 0, var houseName : String, var houseMembers : Int){`
`(var householdId : Int = 0, var householdName : String, var householdMembers : Int){`
I additionally went ahead and changed the houseName, and houseMember variables that were in the override function below as well.
'return "$houseName $houseMembers Members"'
'return "$householdName $householdMembers Members"'
These were also updated in the UnitTest
https://kotlinlang.org/docs/coding-conventions.html


## My commits to my Group’s Repo:
https://github.com/OneList/OneList/commit/c38d91024205cc998b024cbef50e026a1ce5b9a0
https://github.com/OneList/OneList/commit/327c9578b12e4d857b9d14487992f127521f24ef
https://github.com/OneList/OneList/commit/4436fc23ad2b2e0ad17ef042f52a8d8b39667e8c

## Three Technical Concepts learned:
### Learned about Lazy Initialization
Lazy is a way to declare a property that will be initialized lazily, meaning its value will only be computed upon first access. This is useful because it stops you from wasting resources when this property is never actually being called. Additionally this is used if what is actually being initialized is going to use val (read-only), and not be altered after it has been initialized. This allows you to initialize it, and then call upon it without reinitializing it every time.

https://kotlinlang.org/docs/delegated-properties.html#lazy-properties
https://www.tutorialspoint.com/kotlin-property-initialization-using-by-lazy-vs-lateinit

### Learned about mipmap and creating icons
mipmap is part of androids drawable. It lets you create multiple directories that house icons/images of different densities. This insures that no matter what screen density that icon is appearing on, it will be the correct density, and always look sharp, no matter the size of the screen.

https://developer.android.com/reference/android/R.mipmap
https://developer.android.com/studio/write/create-app-icons

### Learned about strings.xml
strings.xml is an xml file that houses an array of strings. Its located in the 'res/values/strings.xml' in the android project directory. This file contains string elements with unique attribute names and a value that represents the strings. These are then referenced using the '@string/string_name'. This makes it easier to manage all the apps strings in one place, as well as makes it easier to create translations to other languages. To make the translation, all that has to be done is create a new resource for example 'values-es' for Español (Spanish). This could house all the strings for the Spanish translation, and all you would have to do is switch to the Spanish version of the resource.

https://developer.android.com/guide/topics/resources/string-resource